### PR TITLE
User roles implementation and user area restrictions

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -2,6 +2,10 @@ security:
     encoders:
         AppBundle\Entity\User: bcrypt
 
+    role_hierarchy:
+        ROLE_USER: ROLE_USER
+        ROLE_ADMIN: [ROLE_USER, ROLE_ADMIN]
+
     providers:
         doctrine:
             entity:
@@ -25,5 +29,4 @@ security:
 
     access_control:
         - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/users, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/, roles: ROLE_USER }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -11,3 +11,7 @@ services:
       - '@security.password_encoder'
     tags:
       -  { name: console.command }
+
+  AppBundle\Form\UserType:
+    arguments: ['%security.role_hierarchy.roles%']
+    tags: ['form.type']

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -5,9 +5,13 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\User;
 use AppBundle\Form\UserType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @Security("has_role('ROLE_ADMIN')")
+ */
 class UserController extends Controller
 {
     /**

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -45,6 +45,11 @@ class User implements UserInterface
      */
     private $tasks;
 
+    /**
+     * @ORM\Column(name="roles", type="array")
+     */
+    private $roles = array();
+
     public function __construct()
     {
         $this->tasks = new ArrayCollection();
@@ -137,7 +142,11 @@ class User implements UserInterface
      */
     public function getRoles()
     {
-        return array('ROLE_USER');
+        if (empty($this->roles)) {
+            return ['ROLE_USER'];
+        }
+
+        return $this->roles;
     }
 
     /**

--- a/src/AppBundle/Form/UserType.php
+++ b/src/AppBundle/Form/UserType.php
@@ -8,9 +8,22 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class UserType extends AbstractType
 {
+    private $roles = [];
+
+    public function __construct($hierarchyRoles)
+    {
+        $roles = array();
+        array_walk_recursive($hierarchyRoles, function($val, $key) use (&$roles) {
+            $roles[$val] = $val;
+        });
+
+        return $this->roles = array_unique($roles);
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -23,6 +36,12 @@ class UserType extends AbstractType
                 'second_options' => ['label' => 'Tapez le mot de passe à nouveau'],
             ])
             ->add('email', EmailType::class, ['label' => 'Adresse email'])
+            ->add('roles', ChoiceType::class, array(
+                'label' => 'Role',
+                'multiple' => true,
+                'expanded' => true,
+                'choices' => $this->roles
+            ))
         ;
     }
 }


### PR DESCRIPTION
Two roles have been implemented: 
- ROLE_USER
- ROLE_ADMIN

Restricted user management area to ROLE_ADMIN.
Changed authorization security for user management: not anymore in access_control but on UserController (as mentionned in [Symfony security best practices](https://symfony.com/doc/3.4/best_practices/security.html#authorization-i-e-denying-access)).

Changed UserType form type by adding roles field. Roles are retrieved dynamically from `security.role_hierarchy.roles`. That way we still have to edit only one file when we want to edit roles.

Closes #2 